### PR TITLE
Fix logging and processing utilities

### DIFF
--- a/strainscape/filter_mutations.py
+++ b/strainscape/filter_mutations.py
@@ -39,7 +39,7 @@ logger = get_logger(__name__)
 perf_monitor = PerformanceMonitor(logger)
 
 # ─── Helper functions --------------------------------------------------------
-def load_mutation_data(snv_file: Path) -> pd.DataFrame:
+def load_mutation_data(snv_file: Path | str) -> pd.DataFrame:
     """Load mutation data from a TSV file.
 
     Parameters
@@ -59,8 +59,12 @@ def load_mutation_data(snv_file: Path) -> pd.DataFrame:
     pd.DataFrame
         Mutation table.
     """
+    snv_file = Path(snv_file)
     logger.info("Loading mutation data from %s", snv_file)
-    return pd.read_csv(snv_file, sep="\t")
+    df = pd.read_csv(snv_file, sep="\t")
+    if "Sample" not in df.columns:
+        df["Sample"] = snv_file.parent.parent.name
+    return df
 
 
 def filter_by_coverage(

--- a/tests/python/unit/test_utils.py
+++ b/tests/python/unit/test_utils.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 import tempfile
 import os
+import logging
 
 # Import the functions to test
 from strainscape.utils import (
@@ -236,4 +237,14 @@ def test_read_large_csv(tmp_path):
 
 def test_get_output_path():
     path = get_output_path("base", "pat", "samp", ".txt")
-    assert path.endswith("pat/samp.txt") 
+    assert path.endswith("pat/samp.txt")
+
+def test_setup_logging_file_without_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    log_file = "temp.log"
+    logger = setup_logging(log_file)
+    logger.info("test")
+    for h in logger.handlers:
+        if isinstance(h, logging.FileHandler):
+            h.flush()
+    assert Path(log_file).exists()


### PR DESCRIPTION
## Summary
- ensure logging file handlers are added when specified
- validate paths in `save_data`
- infer sample name when missing in mutation data
- extend `process_scaffolds` to accept bin directories and stb/metadata files
- handle optional columns in scaffold processing
- allow logging to files in the current directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ae82d1c88321bd3cb9a2b2994fa3