### PR TITLE
Fix map_genes_fast docstring

### DIFF
--- a/strainscape/map_genes.py
+++ b/strainscape/map_genes.py
@@ -25,7 +25,7 @@ def map_genes_fast(trend_path: Path, gene_path: Path, out_path: Path) -> None:
         trend_path: TSV with columns ['scaffold','position','ref_base','new_base']
         gene_path: TSV (Bakta) with header line prefixed '#' and columns including
                    ['Sequence Id','Type','Start','Stop','Strand',
-                    'Locus Tag','Gene','Product','Dbxref']
+                    'Locus Tag','Gene','Product','DbXrefs']
         out_path:   Path to write annotated TSV
     """
     # Load trends


### PR DESCRIPTION
## Summary
- fix Bakta column name in `map_genes_fast` docstring

## Testing
- `pre-commit run --files strainscape/map_genes.py` *(fails: Could not find a version that satisfies the requirement types-pkg-resources)*
- `pytest -q` *(fails: 3 tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6840b34bb270832181dcc45bc64bbe18