### PR TITLE
Fix test failures by including runtime dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ setup(
     packages=find_packages(include=["strainscape", "strainscape.*"]),
     install_requires=[
         "pandas",
-        "numpy"
+        "numpy",
+        "pyyaml",
+        "biopython"
     ],
     author="Renee Oles",
     description="A toolkit for analyzing strain evolution in microbiome data",


### PR DESCRIPTION
## Summary
- fix failing unit tests by installing missing runtime dependencies
- update `setup.py` to specify required packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cd8b18ac83219e0c6d94d1898fa9